### PR TITLE
refactor: module returns

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -1,45 +1,38 @@
 use markov::Chain;
 use std::fs;
-use std::io::stdin;
-use std::io::stdout;
-use std::io::BufWriter;
-use std::io::Read;
-use std::io::Write;
+use std::io::{stdin, stdout, BufWriter, Error, Read, Write};
 use std::path::Path;
 
 // Load resource
 
-pub fn load_source(path: Option<&Path>) -> String {
+pub fn load_resource(path: Option<&Path>) -> Result<String, Error> {
     match path {
-        Some(path) => {
-            return load_file(path);
-        }
-        None => {
-            return load_stdin();
-        }
+        Some(path) => read_file(path),
+        None => read_stdin(),
     }
 }
 
-fn load_file(path: &Path) -> String {
-    let content = fs::read_to_string(path).unwrap();
-    return content;
+fn read_file(path: &Path) -> Result<String, Error> {
+    let content = fs::read_to_string(path)?;
+    Ok(content)
 }
 
-fn load_stdin() -> String {
-    let mut stdin = stdin().lock();
+fn read_stdin() -> Result<String, Error> {
+    let stdin = stdin();
     let mut buffer = String::new();
-    stdin.read_to_string(&mut buffer).unwrap();
-    return buffer;
+    stdin.lock().read_to_string(&mut buffer)?;
+    Ok(buffer)
 }
 
 // Write resource
 
-pub fn write_stdout(chain: &Chain<String>, repeat: &usize) {
-    let stdout = stdout().lock();
+pub fn write_stdout(chain: &Chain<String>, repeat: &usize) -> Result<(), Error> {
+    let stdout = stdout();
     let mut buffer = BufWriter::new(stdout);
 
     // Write generated string
     for s in chain.str_iter_for(*repeat) {
-        writeln!(buffer, "{}", s.replace(" ", "")).unwrap();
+        writeln!(buffer, "{}", s.replace(' ', ""))?;
     }
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod io;
 mod markov;
 mod tokenize;
 
+use std::io::Error;
 use std::path::PathBuf;
 
 use clap::Parser;
@@ -25,14 +26,17 @@ struct Arg {
     repeat: usize,
 }
 
-fn main() {
+fn main() -> Result<(), Error> {
     let args: Arg = Arg::parse();
 
     // Load resource
-    let source = io::load_source(args.input.as_deref());
-    let tokens = tokenize::tokenize(&source);
+    let source = io::load_resource(args.input.as_deref())?;
+    let tokens = tokenize::tokenize(source.as_str());
+
     // Create chain
     let chain = markov::build_chain(&tokens, &args.state_size);
+
     // Write results
-    io::write_stdout(&chain, &args.repeat);
+    io::write_stdout(&chain, &args.repeat)?;
+    Ok(())
 }

--- a/src/markov.rs
+++ b/src/markov.rs
@@ -5,5 +5,5 @@ pub fn build_chain(source: &Vec<String>, order: &usize) -> Chain<String> {
     for s in source {
         chain.feed_str(s);
     }
-    return chain;
+    chain
 }

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -27,7 +27,7 @@ pub fn tokenize(source: &str) -> Vec<String> {
     // Tokenize
     let tokens = formatted_source
         .lines()
-        .map(|line| tokenizer.tokenize(line).unwrap().to_owned())
+        .map(|line| tokenizer.tokenize(line).unwrap())
         .map(|tokens| {
             tokens
                 .into_iter()
@@ -37,5 +37,5 @@ pub fn tokenize(source: &str) -> Vec<String> {
         })
         .collect();
 
-    return tokens;
+    tokens
 }


### PR DESCRIPTION
- Remove module returns.
- Change function returns to `Result` in "io".