### PR TITLE
ci: change dependabot config `versioning-strategy`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
       - "RShirohara"
     reviewers:
       - "RShirohara"
+    versioning-strategy: increase
     groups:
       lindera:
         patterns:

--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -31,8 +31,9 @@ jobs:
       - name: Setup dependencies cache
         uses: Swatinem/rust-cache@v2.6.2
         with:
-          key: rust-cache-${{ hashFiles('./Cargo.toml') }}
-          shared-key: rust-cache-
+          prefix-key: rust-cache
+          shared-key: ${{ hashFiles('./Cargo.toml') }}
+          key: ""
 
       - name: Build
         run: |
@@ -58,7 +59,9 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2.6.2
         with:
-          shared-key: ${{ github.workflow }}
+          prefix-key: rust-cache
+          shared-key: ${{ hashFiles('./Cargo.toml') }}
+          key: ""
 
       - name: Setup reviewdog
         uses: reviewdog/action-setup@v1.0.6

--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.6.0
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -29,7 +29,7 @@ jobs:
           target: ${{ env.RUST_TOOLCHAIN_TARGET }}
 
       - name: Setup dependencies cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v2.6.2
         with:
           key: rust-cache-${{ hashFiles('./Cargo.toml') }}
           shared-key: rust-cache-
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.6.0
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -56,12 +56,12 @@ jobs:
           target: ${{ env.RUST_TOOLCHAIN_TARGET }}
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v2.6.2
         with:
           shared-key: ${{ github.workflow }}
 
       - name: Setup reviewdog
-        uses: reviewdog/action-setup@v1
+        uses: reviewdog/action-setup@v1.0.6
 
       - name: Run clippy
         env:

--- a/.github/workflows/cleanup-cache.yaml
+++ b/.github/workflows/cleanup-cache.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.6.0
 
       - name: Setup gh-actions-cache
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.6.0
 
       - name: Build and Release
         uses: rust-build/rust-build.action@v1.4.3


### PR DESCRIPTION
- Change dependabot config `versioning-strategy`.
- Add action version details.
- Fix ci-cache key.